### PR TITLE
共识产生分叉

### DIFF
--- a/consensus/alien/alien.go
+++ b/consensus/alien/alien.go
@@ -594,6 +594,18 @@ func (a *Alien) Prepare(chain consensus.ChainReader, header *types.Header) error
 
 	// Set the correct difficulty
 	header.Difficulty = new(big.Int).Set(defaultDifficulty)
+
+	number := header.Number.Uint64()
+
+	parent := chain.GetHeader(header.ParentHash, number-1)
+	if parent == nil {
+		return  consensus.ErrUnknownAncestor
+	}
+	header.Time = new(big.Int).Add(parent.Time, new(big.Int).SetUint64(a.config.Period))
+	if header.Time.Int64() < time.Now().Unix() {
+		header.Time = big.NewInt(time.Now().Unix())
+	}
+
 	// If now is later than genesis timestamp, skip prepare
 	if a.config.GenesisTimestamp < uint64(time.Now().Unix()) {
 		return nil
@@ -743,20 +755,12 @@ func (a *Alien) mcConfirmBlock(chain consensus.ChainReader, header *types.Header
 // rewards given, and returns the final block.
 func (a *Alien) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
 
-	number := header.Number.Uint64()
 
 	// Mix digest is reserved for now, set to empty
 	header.MixDigest = common.Hash{}
 
 	// Ensure the timestamp has the correct delay
-	parent := chain.GetHeader(header.ParentHash, number-1)
-	if parent == nil {
-		return nil, consensus.ErrUnknownAncestor
-	}
-	header.Time = new(big.Int).Add(parent.Time, new(big.Int).SetUint64(a.config.Period))
-	if header.Time.Int64() < time.Now().Unix() {
-		header.Time = big.NewInt(time.Now().Unix())
-	}
+
 
 	// Ensure the extra data has all it's components
 	if len(header.Extra) < extraVanity {

--- a/consensus/alien/snapshot.go
+++ b/consensus/alien/snapshot.go
@@ -1046,7 +1046,7 @@ func (s *Snapshot) updateSnapshotByVotes(votes []Vote, headerNumber *big.Int) {
 		}
 
 		s.Votes[vote.Voter] = &Vote{vote.Voter, vote.Candidate, new(big.Int).Set(vote.Stake)}
-		s.Voters[vote.Voter] = headerNumber
+		s.Voters[vote.Voter] = new(big.Int).Set(headerNumber)
 	}
 }
 


### PR DESCRIPTION
1. 给header.Time赋值时如果在Finalize函数中,在收到远端挖出的块的时候,会在验证state的时候也会再次调用Finalize函数,将再次给header.Time赋值,使得state状态不一样,从而产生分叉.模拟重现,部署智能合约,合约中调用now()函数给变量赋值,由于now()函数取值为header.Time值,使得打包块打包的header.Time值与验证时header.Time值不一样,从事验证时stateRoot验证不通过,产生bad block从而分叉.

2. 指针变量赋值产生浅拷贝.